### PR TITLE
Fix CI test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm test -- --runInBand
+        run: npm test


### PR DESCRIPTION
## Summary
- fix CI workflow to run vitest without unsupported --runInBand flag

## Testing
- not run (workflow change only)