### PR TITLE
Add layout skeleton and remove sample test

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,84 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.app-root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: #f5f7fb;
+}
+
+.app-bar {
+  position: sticky;
+  top: 0;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.app-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: #ffffff;
+}
+
+.left-panel {
+  width: 220px;
+  border-right: 1px solid #e0e4ec;
+}
+
+.right-panel {
+  width: 260px;
+  border-left: 1px solid #e0e4ec;
+}
+
+.canvas-area {
+  flex: 1;
+  padding: 1rem;
+  min-width: 0;
+  overflow: auto;
+  background: repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.02),
+      rgba(0, 0, 0, 0.02) 1px,
+      transparent 1px,
+      transparent 16px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.02),
+      rgba(0, 0, 0, 0.02) 1px,
+      transparent 1px,
+      transparent 16px
+    );
+}
+
+.canvas-placeholder {
+  height: 100%;
+  min-height: 480px;
+  border-style: dashed;
+  display: grid;
+  place-items: center;
   text-align: center;
+  color: #606c80;
+  background: rgba(255, 255, 255, 0.6);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid #e0e4ec;
+  background: #ffffff;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,93 @@
-import { useState } from "react";
-import reactLogo from "./assets/react.svg";
-import viteLogo from "/vite.svg";
+import AppBar from "@mui/material/AppBar";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
+import Paper from "@mui/material/Paper";
+import Stack from "@mui/material/Stack";
+import Toolbar from "@mui/material/Toolbar";
+import Typography from "@mui/material/Typography";
 import "./App.css";
 
-function App() {
-  const [count, setCount] = useState(0);
+const actions = ["New", "Open", "Save", "Export", "Undo", "Redo"];
 
+function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
-    </>
+    <Box className="app-root">
+      <AppBar position="static" className="app-bar" elevation={1}>
+        <Toolbar className="toolbar" variant="dense">
+          <Typography variant="h6" component="div">
+            Power Block Diagram Editor
+          </Typography>
+          <Stack direction="row" spacing={1}>
+            {actions.map((label) => (
+              <Button key={label} color="inherit" size="small" variant="text">
+                {label}
+              </Button>
+            ))}
+          </Stack>
+        </Toolbar>
+      </AppBar>
+
+      <Box className="app-body">
+        <Box className="panel left-panel">
+          <Typography variant="subtitle1" fontWeight={600}>
+            Palette
+          </Typography>
+          <Divider />
+          <Stack spacing={1} mt={2}>
+            <Button variant="contained" size="small" fullWidth>
+              Add Type A
+            </Button>
+            <Button variant="contained" size="small" fullWidth>
+              Add Type B
+            </Button>
+            <Button variant="contained" size="small" fullWidth>
+              Add Type C
+            </Button>
+          </Stack>
+        </Box>
+
+        <Box className="canvas-area">
+          <Paper variant="outlined" className="canvas-placeholder">
+            <Typography variant="subtitle1" fontWeight={600}>
+              Canvas
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              React Flow will render here
+            </Typography>
+          </Paper>
+        </Box>
+
+        <Box className="panel right-panel">
+          <Typography variant="subtitle1" fontWeight={600}>
+            Properties
+          </Typography>
+          <Divider />
+          <Stack spacing={1} mt={2}>
+            <Typography variant="body2" color="text.secondary">
+              Nothing selected
+            </Typography>
+          </Stack>
+
+          <Divider sx={{ my: 2 }} />
+          <Typography variant="subtitle1" fontWeight={600}>
+            Validation
+          </Typography>
+          <Stack spacing={0.5} mt={1}>
+            <Typography variant="body2">Errors: 0</Typography>
+            <Typography variant="body2">Warnings: 0</Typography>
+            <Typography variant="body2">Uncertain loads: 0</Typography>
+          </Stack>
+        </Box>
+      </Box>
+
+      <Box className="status-bar">
+        <Typography variant="body2">Status: Ready</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Nets: 0 | Errors: 0 | Warnings: 0 | Unassigned nets: 0 | Uncertain loads: 0
+        </Typography>
+      </Box>
+    </Box>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,25 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f7fb;
+  color: #1f2430;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+a {
+  color: inherit;
+  text-decoration: none;
 }

--- a/src/sample.test.ts
+++ b/src/sample.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from "vitest";
-
-describe("sample", () => {
-  it("runs vitest", () => {
-    expect(true).toBe(true);
-  });
-});


### PR DESCRIPTION
## Summary
- replace Vite starter with editor layout skeleton (header, palette, canvas placeholder, properties, status bar)
- update global styles for full-height layout and grid background placeholder
- remove sample.test.ts placeholder test

## Testing
- npm test
- npm run lint
- npm run build