### PR TITLE
Add format check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Format check
+        run: npm run format:check
+
       - name: Lint
         run: npm run lint
 

--- a/src/App.css
+++ b/src/App.css
@@ -46,7 +46,8 @@
   padding: 1rem;
   min-width: 0;
   overflow: auto;
-  background: repeating-linear-gradient(
+  background:
+    repeating-linear-gradient(
       0deg,
       rgba(0, 0, 0, 0.02),
       rgba(0, 0, 0, 0.02) 1px,

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,11 @@
 :root {
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
   font-synthesis: none;

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -1,4 +1,11 @@
-import type { Block, BlockB, BlockC, Net, ValidationLevel, ValidationResult } from "../types/diagram";
+import type {
+  Block,
+  BlockB,
+  BlockC,
+  Net,
+  ValidationLevel,
+  ValidationResult,
+} from "../types/diagram";
 
 const issue = (level: ValidationLevel, message: string, targetId?: string): ValidationResult => ({
   id: `${level}-${targetId ?? "global"}-${message}`.replace(/\s+/g, "-"),
@@ -12,7 +19,11 @@ const isToleranceValid = (tolerance?: number): boolean => {
   return tolerance >= 0 && tolerance <= 100;
 };
 
-export const isVoltageWithinTolerance = (netVoltage: number, required: number, tolerancePercent?: number): boolean => {
+export const isVoltageWithinTolerance = (
+  netVoltage: number,
+  required: number,
+  tolerancePercent?: number,
+): boolean => {
   const tolerance = tolerancePercent ?? 0;
   if (!isToleranceValid(tolerance)) return false;
   const delta = Math.abs(netVoltage - required);
@@ -25,7 +36,9 @@ const validateVoltage = (net: Net, required: number): ValidationResult[] => {
     return [issue("error", "Net tolerance must be within 0-100%", net.id)];
   }
   const within = isVoltageWithinTolerance(net.voltage, required, net.tolerance);
-  return within ? [] : [issue("error", `Voltage mismatch: net=${net.voltage}V required=${required}V`, net.id)];
+  return within
+    ? []
+    : [issue("error", `Voltage mismatch: net=${net.voltage}V required=${required}V`, net.id)];
 };
 
 const validatePhase = (net: Net, required: number): ValidationResult[] => {
@@ -35,7 +48,10 @@ const validatePhase = (net: Net, required: number): ValidationResult[] => {
   return [];
 };
 
-const validateTypeBLoad = (block: BlockB, net: Net): { issues: ValidationResult[]; current?: number } => {
+const validateTypeBLoad = (
+  block: BlockB,
+  net: Net,
+): { issues: ValidationResult[]; current?: number } => {
   const issues: ValidationResult[] = [];
   issues.push(...validateVoltage(net, block.rating.V_in));
   issues.push(...validatePhase(net, block.rating.phase));


### PR DESCRIPTION
## Summary
- add prettier format:check to CI workflow
- run prettier on existing sources (App.css/index.css/validation.ts)

## Testing
- npm run format:check
- npm run lint
- npm run build