### PR TITLE
Add project.json serialization utilities

### DIFF
--- a/src/services/projectIO.test.ts
+++ b/src/services/projectIO.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { createEmptyProject, parseProject, serializeProject } from "./projectIO";
+
+describe("projectIO", () => {
+  it("serializes and parses a project", () => {
+    const project = createEmptyProject();
+    const json = serializeProject(project);
+    const parsed = parseProject(json);
+    expect(parsed.schema_version).toBe("1.0.0");
+    expect(parsed.meta.title).toBe("Untitled");
+  });
+
+  it("throws on unsupported schema version", () => {
+    const json = JSON.stringify({ schema_version: "2.0.0" });
+    expect(() => parseProject(json)).toThrow(/Unsupported schema_version/);
+  });
+
+  it("throws when required fields are missing", () => {
+    const json = JSON.stringify({ schema_version: "1.0.0", meta: {} });
+    expect(() => parseProject(json)).toThrow(/Missing required fields/);
+  });
+});

--- a/src/services/projectIO.ts
+++ b/src/services/projectIO.ts
@@ -1,0 +1,33 @@
+import type { Project } from "../types/diagram";
+
+export const serializeProject = (project: Project): string => {
+  return JSON.stringify(project, null, 2);
+};
+
+export const parseProject = (json: string): Project => {
+  const parsed = JSON.parse(json) as Partial<Project>;
+
+  if (parsed.schema_version !== "1.0.0") {
+    throw new Error(`Unsupported schema_version: ${parsed.schema_version ?? "unknown"}`);
+  }
+
+  if (!parsed.meta || !parsed.nets || !parsed.blocks || !parsed.connections || !parsed.layout) {
+    throw new Error("Missing required fields in project.json");
+  }
+
+  return parsed as Project;
+};
+
+export const createEmptyProject = (): Project => ({
+  schema_version: "1.0.0",
+  meta: {
+    title: "Untitled",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    author: "unknown",
+  },
+  nets: [],
+  blocks: [],
+  connections: [],
+  layout: { blocks: {}, edges: {} },
+});


### PR DESCRIPTION
## Summary
- add projectIO helpers to serialize/parse project.json with schema_version check
- provide createEmptyProject helper
- add unit tests for serialization and validation errors

## Testing
- npm run format:check
- npm run lint
- npm run test
- npm run build