### PR TITLE
Extract shared constants from App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,11 @@ import type { EdgeProps } from "reactflow";
 import { useMemo, useState } from "react";
 import { useDiagramState } from "./state/DiagramState";
 import { wouldCreateCycle } from "./lib/graph";
+import { defaultNet, typeLabels } from "./lib/constants";
 import type {
   ValidationResult,
   Block,
   BlockType,
-  Net,
   RatingA,
   RatingB,
   RatingC,
@@ -40,21 +40,6 @@ const SmoothEdge = (props: EdgeProps) => {
   });
 
   return <BaseEdge {...props} path={path} />;
-};
-
-const defaultNet: Net = {
-  id: "net-ac200",
-  kind: "AC",
-  voltage: 200,
-  phase: 1,
-  label: "AC200V",
-  tolerance: 10,
-};
-
-const typeLabels: Record<BlockType, string> = {
-  A: "Breaker / Passive",
-  B: "Load",
-  C: "Converter / Source",
 };
 
 function App() {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,16 @@
+import type { BlockType, Net } from "../types/diagram";
+
+export const defaultNet: Net = {
+  id: "net-ac200",
+  kind: "AC",
+  voltage: 200,
+  phase: 1,
+  label: "AC200V",
+  tolerance: 10,
+};
+
+export const typeLabels: Record<BlockType, string> = {
+  A: "Breaker / Passive",
+  B: "Load",
+  C: "Converter / Source",
+};


### PR DESCRIPTION
## Summary
- Move typeLabels and defaultNet out of App.tsx into src/lib/constants.ts
- Import shared constants where needed to reduce inline definitions

## Testing
- npm run lint
- npm test