### PR TITLE
Extract node editing logic into hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import StatusBar from "./components/StatusBar";
 import ProjectDialog from "./components/ProjectDialog";
 import { useProjectIO } from "./hooks/useProjectIO";
 import { useNodeEditing } from "./hooks/useNodeEditing";
+import { defaultRatings } from "./lib/ratingHelpers";
 import "./App.css";
 import "reactflow/dist/style.css";
 
@@ -58,7 +59,7 @@ function App() {
     handleTypeCRatingChange,
     handleDeleteSelected,
     resetSelection,
-  } = useNodeEditing({ nodes, edges, setNodes, deleteItems });
+  } = useNodeEditing({ nodes, edges, setNodes, deleteItems, defaultRatings });
   const {
     dialogState,
     setDialogText,

--- a/src/hooks/useNodeEditing.ts
+++ b/src/hooks/useNodeEditing.ts
@@ -10,9 +10,16 @@ type UseNodeEditingArgs = {
   edges: Edge[];
   setNodes: (updater: (prev: Node[]) => Node[]) => void;
   deleteItems: (nodeIds: string[], edgeIds: string[]) => void;
+  defaultRatings: Record<BlockType, Block["rating"]>;
 };
 
-export const useNodeEditing = ({ nodes, edges, setNodes, deleteItems }: UseNodeEditingArgs) => {
+export const useNodeEditing = ({
+  nodes,
+  edges,
+  setNodes,
+  deleteItems,
+  defaultRatings,
+}: UseNodeEditingArgs) => {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
 
@@ -45,10 +52,7 @@ export const useNodeEditing = ({ nodes, edges, setNodes, deleteItems }: UseNodeE
     );
   };
 
-  const handleNodeTypeChange = (
-    value: BlockType,
-    defaultRatings: Record<BlockType, Block["rating"]>,
-  ) => {
+  const handleNodeTypeChange = (value: BlockType) => {
     if (!selectedNodeId) return;
     setNodes((prev) =>
       prev.map((n) =>


### PR DESCRIPTION
## Summary
- Move node/edge selection and editing handlers into a custom hook 
- App.tsx now consumes the hook and passes callbacks/state to child components
- Keeps existing behavior for label/type/rating updates and deletion

## Testing
- npm run lint
- npm test