### PR TITLE
Align net stats display and labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,6 +101,7 @@ function App() {
     const nodeNets = new Map<string, Set<string>>();
     const netBlocks = new Map<string, Block[]>();
     const invalidNetRefs: string[] = [];
+    const referencedNets = new Set<string>();
 
     edges.forEach((edge) => {
       const netId = (edge.data as { netId?: string } | undefined)?.netId;
@@ -110,6 +111,7 @@ function App() {
         if (!nodeNets.has(edge.target)) nodeNets.set(edge.target, new Set());
         nodeNets.get(edge.source)?.add(netId);
         nodeNets.get(edge.target)?.add(netId);
+        referencedNets.add(netId);
       }
     });
 
@@ -171,6 +173,7 @@ function App() {
 
     const errors = issues.filter((r) => r.level === "error").length;
     const warnings = issues.filter((r) => r.level === "warn").length;
+    const orphanNets = nets.filter((net) => !referencedNets.has(net.id)).length;
 
     return {
       issues,
@@ -180,7 +183,8 @@ function App() {
         warnings,
         uncertainLoads: totalUncertain,
         nets: nets.length || 1,
-        unassignedNets: unassignedEdges,
+        unassignedEdges,
+        orphanNets,
       },
     };
   }, [nodes, edges, nets]);
@@ -265,6 +269,11 @@ function App() {
             <Typography variant="body2">
               Uncertain loads: {validationStats.uncertainLoads}
             </Typography>
+            <Typography variant="body2">Nets: {validationStats.nets}</Typography>
+            <Typography variant="body2">
+              Unassigned edges: {validationStats.unassignedEdges}
+            </Typography>
+            <Typography variant="body2">Orphan nets: {validationStats.orphanNets}</Typography>
           </Stack>
 
           <Box mt={1}>
@@ -311,7 +320,8 @@ function App() {
         errors={validationStats.errors}
         warnings={validationStats.warnings}
         nets={validationStats.nets}
-        unassignedNets={validationStats.unassignedNets}
+        unassignedEdges={validationStats.unassignedEdges}
+        orphanNets={validationStats.orphanNets}
         uncertainLoads={validationStats.uncertainLoads}
       />
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -5,16 +5,24 @@ type Props = {
   errors: number;
   warnings: number;
   nets: number;
-  unassignedNets: number;
+  unassignedEdges: number;
   uncertainLoads: number;
+  orphanNets: number;
 };
 
-export const StatusBar = ({ errors, warnings, nets, unassignedNets, uncertainLoads }: Props) => (
+export const StatusBar = ({
+  errors,
+  warnings,
+  nets,
+  unassignedEdges,
+  uncertainLoads,
+  orphanNets,
+}: Props) => (
   <Box className="status-bar">
     <Typography variant="body2">Status: Ready</Typography>
     <Typography variant="body2" color="text.secondary">
-      Nets: {nets} | Errors: {errors} | Warnings: {warnings} | Unassigned edges: {unassignedNets} |
-      Uncertain loads: {uncertainLoads}
+      Nets: {nets} | Errors: {errors} | Warnings: {warnings} | Unassigned edges: {unassignedEdges} |
+      Orphan nets: {orphanNets} | Uncertain loads: {uncertainLoads}
     </Typography>
   </Box>
 );


### PR DESCRIPTION
## Summary
- 検証サマリで参照net/unassigned/orphan netを区別し、ステータスバーと右パネルで同じ集計を表示
- 未割当エッジ数を明示し、孤立net数を追加。ラベルを誤解のない表記に修正

## Testing
- npm run format
- npm run lint
- npm test
- npm run build
