### PR TITLE
Add standalone net management panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import DiagramCanvas from "./components/DiagramCanvas";
 import PropertiesPanel from "./components/PropertiesPanel";
 import StatusBar from "./components/StatusBar";
 import ProjectDialog from "./components/ProjectDialog";
+import NetManager from "./components/NetManager";
 import { useProjectIO } from "./hooks/useProjectIO";
 import { useNodeEditing, type NodeData } from "./hooks/useNodeEditing";
 import { defaultRatings } from "./lib/ratingHelpers";
@@ -257,6 +258,16 @@ function App() {
             onUpdateNetAttributes={updateNetAttributes}
             onDeleteNet={removeNet}
             onDeleteSelected={handleDeleteSelected}
+          />
+
+          <Divider sx={{ my: 2 }} />
+          <NetManager
+            nets={nets}
+            netEdgeCounts={netEdgeCounts}
+            addNet={addNet}
+            updateNetLabel={updateNetLabel}
+            updateNetAttributes={updateNetAttributes}
+            removeNet={removeNet}
           />
 
           <Divider sx={{ my: 2 }} />

--- a/src/components/NetManager.tsx
+++ b/src/components/NetManager.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Divider from "@mui/material/Divider";
+import MenuItem from "@mui/material/MenuItem";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import type { Net } from "../types/diagram";
+import { toNumberOrUndefined } from "../lib/ratingHelpers";
+
+type Props = {
+  nets: Net[];
+  netEdgeCounts: Record<string, number>;
+  addNet: () => string;
+  updateNetLabel: (netId: string, label: string) => void;
+  updateNetAttributes: (netId: string, updates: Partial<Net>) => void;
+  removeNet: (netId: string) => boolean;
+};
+
+const NetManager = ({
+  nets,
+  netEdgeCounts,
+  addNet,
+  updateNetLabel,
+  updateNetAttributes,
+  removeNet,
+}: Props) => {
+  const [selectedNetId, setSelectedNetId] = useState<string | null>(nets[0]?.id ?? null);
+  const effectiveNetId = useMemo(() => {
+    if (selectedNetId && nets.find((net) => net.id === selectedNetId)) return selectedNetId;
+    return nets[0]?.id ?? null;
+  }, [nets, selectedNetId]);
+
+  const selectedNet = useMemo(
+    () => nets.find((net) => net.id === effectiveNetId) ?? null,
+    [nets, effectiveNetId],
+  );
+
+  const handleAdd = () => {
+    const id = addNet();
+    setSelectedNetId(id);
+  };
+
+  const handleDelete = () => {
+    if (!selectedNet) return;
+    removeNet(selectedNet.id);
+  };
+
+  const edgeCount = selectedNet ? (netEdgeCounts[selectedNet.id] ?? 0) : 0;
+
+  return (
+    <Box>
+      <Typography variant="subtitle1" fontWeight={600}>
+        Nets
+      </Typography>
+      <Divider />
+      <Stack spacing={1} mt={1}>
+        <Stack direction="row" spacing={1}>
+          <TextField
+            size="small"
+            label="Select Net"
+            select
+            value={effectiveNetId ?? ""}
+            onChange={(e) => setSelectedNetId(e.target.value || null)}
+            sx={{ flex: 1 }}
+          >
+            {nets.map((net) => (
+              <MenuItem key={net.id} value={net.id}>
+                {net.label}
+              </MenuItem>
+            ))}
+          </TextField>
+          <Button variant="contained" size="small" onClick={handleAdd}>
+            Add
+          </Button>
+        </Stack>
+
+        {selectedNet ? (
+          <Stack spacing={1}>
+            <TextField
+              size="small"
+              label="Name"
+              value={selectedNet.label}
+              onChange={(e) => updateNetLabel(selectedNet.id, e.target.value)}
+            />
+            <TextField
+              size="small"
+              label="Kind"
+              select
+              value={selectedNet.kind}
+              onChange={(e) =>
+                updateNetAttributes(selectedNet.id, { kind: e.target.value as Net["kind"] })
+              }
+            >
+              <MenuItem value="AC">AC</MenuItem>
+              <MenuItem value="DC">DC</MenuItem>
+              <MenuItem value="SIGNAL">SIGNAL</MenuItem>
+            </TextField>
+            <TextField
+              size="small"
+              label="Voltage (V)"
+              type="number"
+              inputProps={{ step: 0.01, min: 0, inputMode: "decimal" }}
+              value={selectedNet.voltage}
+              onChange={(e) =>
+                updateNetAttributes(selectedNet.id, {
+                  voltage: toNumberOrUndefined(e.target.value),
+                })
+              }
+            />
+            <TextField
+              size="small"
+              label="Tolerance (%)"
+              type="number"
+              inputProps={{ step: 0.1, min: 0, max: 100, inputMode: "decimal" }}
+              value={selectedNet.tolerance ?? ""}
+              onChange={(e) =>
+                updateNetAttributes(selectedNet.id, {
+                  tolerance: toNumberOrUndefined(e.target.value),
+                })
+              }
+            />
+            <TextField
+              size="small"
+              label="Phase"
+              select
+              value={selectedNet.phase}
+              onChange={(e) =>
+                updateNetAttributes(selectedNet.id, {
+                  phase: Number(e.target.value) as 0 | 1 | 3,
+                })
+              }
+            >
+              {[0, 1, 3].map((phase) => (
+                <MenuItem key={phase} value={phase}>
+                  {phase}
+                </MenuItem>
+              ))}
+            </TextField>
+            <Button
+              variant="outlined"
+              size="small"
+              color="warning"
+              disabled={edgeCount > 0}
+              onClick={handleDelete}
+            >
+              Delete Net {edgeCount > 0 ? `(in use: ${edgeCount})` : ""}
+            </Button>
+          </Stack>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            No net selected.
+          </Typography>
+        )}
+      </Stack>
+    </Box>
+  );
+};
+
+export default NetManager;


### PR DESCRIPTION
## Summary
- 右パネルに Net 管理セクションを追加し、エッジ選択に依存せず net の追加/名称変更/種別/電圧/相数/許容差編集を可能に
- 未参照時のみ削除できるようにし、使用中はボタンを無効化
- 既存のエッジ選択時の Net 編集と併用可能

## Testing
- npm run format
- npm run lint
- npm test
- npm run build
