### PR TITLE
Validate project net references on load

### DIFF
--- a/src/services/projectIO.test.ts
+++ b/src/services/projectIO.test.ts
@@ -19,4 +19,43 @@ describe("projectIO", () => {
     const json = JSON.stringify({ schema_version: "1.0.0", meta: {} });
     expect(() => parseProject(json)).toThrow(/Missing required fields/);
   });
+
+  it("throws when a connection references an unknown net", () => {
+    const project = {
+      schema_version: "1.0.0",
+      meta: { title: "t", created_at: "", updated_at: "", author: "" },
+      nets: [{ id: "net-1", kind: "AC", voltage: 100, phase: 1, label: "N1" }],
+      blocks: [],
+      connections: [{ from: "A:out", to: "B:in", net: "net-missing", label: "c1" }],
+      layout: { blocks: {}, edges: {} },
+    };
+    expect(() => parseProject(JSON.stringify(project))).toThrow(/unknown net id/i);
+  });
+
+  it("throws when a connection is missing net field", () => {
+    const project = {
+      schema_version: "1.0.0",
+      meta: { title: "t", created_at: "", updated_at: "", author: "" },
+      nets: [{ id: "net-1", kind: "AC", voltage: 100, phase: 1, label: "N1" }],
+      blocks: [],
+      connections: [{ from: "A:out", to: "B:in", label: "c1" }],
+      layout: { blocks: {}, edges: {} },
+    };
+    expect(() => parseProject(JSON.stringify(project))).toThrow(/missing 'net'/i);
+  });
+
+  it("throws when net ids are duplicated", () => {
+    const project = {
+      schema_version: "1.0.0",
+      meta: { title: "t", created_at: "", updated_at: "", author: "" },
+      nets: [
+        { id: "net-1", kind: "AC", voltage: 100, phase: 1, label: "N1" },
+        { id: "net-1", kind: "AC", voltage: 200, phase: 1, label: "N2" },
+      ],
+      blocks: [],
+      connections: [{ from: "A:out", to: "B:in", net: "net-1", label: "c1" }],
+      layout: { blocks: {}, edges: {} },
+    };
+    expect(() => parseProject(JSON.stringify(project))).toThrow(/duplicate net id/i);
+  });
 });

--- a/src/services/projectIO.ts
+++ b/src/services/projectIO.ts
@@ -15,6 +15,30 @@ export const parseProject = (json: string): Project => {
     throw new Error("Missing required fields in project.json");
   }
 
+  const netIds = new Set<string>();
+  parsed.nets.forEach((net) => {
+    if (!net.id) {
+      throw new Error("Net id is required");
+    }
+    if (netIds.has(net.id)) {
+      throw new Error(`Duplicate net id found: ${net.id}`);
+    }
+    netIds.add(net.id);
+  });
+
+  parsed.connections.forEach((conn, idx) => {
+    const net = (conn as { net?: string | null }).net;
+    if (net === undefined) {
+      throw new Error(`Connection at index ${idx} is missing 'net'`);
+    }
+    if (net !== null && typeof net !== "string") {
+      throw new Error(`Connection at index ${idx} has invalid net value`);
+    }
+    if (typeof net === "string" && !netIds.has(net)) {
+      throw new Error(`Connection references unknown net id: ${net}`);
+    }
+  });
+
   return parsed as Project;
 };
 


### PR DESCRIPTION
## Summary
- project.json 読み込み時に net ID の重複、未知 net 参照、net 欠落を検出してエラーとする
- parseProject に検証ロジックを追加し、ロード時に UI へエラーメッセージを返せるように
- projectIO のテストを拡充（未知 net / net 欠落 / 重複 net ID）

## Testing
- npm run format
- npm run lint
- npm test
- npm run build
