### PR TITLE
Add undo/redo support for net operations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,10 @@ function App() {
     updateNetLabel,
     updateNetAttributes,
     removeNet,
+    undoNetAction,
+    redoNetAction,
+    canUndoNet,
+    canRedoNet,
   } = useDiagramState();
   const {
     selectedNode,
@@ -268,6 +272,10 @@ function App() {
             updateNetLabel={updateNetLabel}
             updateNetAttributes={updateNetAttributes}
             removeNet={removeNet}
+            undoNetAction={undoNetAction}
+            redoNetAction={redoNetAction}
+            canUndoNet={canUndoNet}
+            canRedoNet={canRedoNet}
           />
 
           <Divider sx={{ my: 2 }} />

--- a/src/components/NetManager.tsx
+++ b/src/components/NetManager.tsx
@@ -16,6 +16,10 @@ type Props = {
   updateNetLabel: (netId: string, label: string) => void;
   updateNetAttributes: (netId: string, updates: Partial<Net>) => void;
   removeNet: (netId: string) => boolean;
+  undoNetAction: () => boolean;
+  redoNetAction: () => boolean;
+  canUndoNet: boolean;
+  canRedoNet: boolean;
 };
 
 const NetManager = ({
@@ -25,6 +29,10 @@ const NetManager = ({
   updateNetLabel,
   updateNetAttributes,
   removeNet,
+  undoNetAction,
+  redoNetAction,
+  canUndoNet,
+  canRedoNet,
 }: Props) => {
   const [selectedNetId, setSelectedNetId] = useState<string | null>(nets[0]?.id ?? null);
   const effectiveNetId = useMemo(() => {
@@ -73,6 +81,12 @@ const NetManager = ({
           </TextField>
           <Button variant="contained" size="small" onClick={handleAdd}>
             Add
+          </Button>
+          <Button variant="outlined" size="small" disabled={!canUndoNet} onClick={undoNetAction}>
+            Undo
+          </Button>
+          <Button variant="outlined" size="small" disabled={!canRedoNet} onClick={redoNetAction}>
+            Redo
           </Button>
         </Stack>
 

--- a/src/state/DiagramState.test.tsx
+++ b/src/state/DiagramState.test.tsx
@@ -61,4 +61,44 @@ describe("DiagramState net helpers", () => {
     expect(removed).toBe(true);
     expect(result.current.nets.find((n) => n.id === netId)).toBeUndefined();
   });
+
+  it("undoes and redoes net add", () => {
+    const { result } = renderHook(() => useDiagramState(), { wrapper });
+    const initialCount = result.current.nets.length;
+    let newNetId = "";
+    act(() => {
+      newNetId = result.current.addNet();
+    });
+    expect(result.current.nets.length).toBe(initialCount + 1);
+
+    let undone = false;
+    act(() => {
+      undone = result.current.undoNetAction();
+    });
+    expect(undone).toBe(true);
+    expect(result.current.nets.find((n) => n.id === newNetId)).toBeUndefined();
+
+    let redone = false;
+    act(() => {
+      redone = result.current.redoNetAction();
+    });
+    expect(redone).toBe(true);
+    expect(result.current.nets.length).toBe(initialCount + 1);
+  });
+
+  it("undoes net attribute update", () => {
+    const { result } = renderHook(() => useDiagramState(), { wrapper });
+    const netId = result.current.nets[0].id;
+    const originalVoltage = result.current.nets[0].voltage;
+
+    act(() => {
+      result.current.updateNetAttributes(netId, { voltage: originalVoltage + 50 });
+    });
+    expect(result.current.nets.find((n) => n.id === netId)?.voltage).toBe(originalVoltage + 50);
+
+    act(() => {
+      result.current.undoNetAction();
+    });
+    expect(result.current.nets.find((n) => n.id === netId)?.voltage).toBe(originalVoltage);
+  });
 });


### PR DESCRIPTION
## Summary
- Net 操作（追加/削除/割当/属性更新）用の履歴スタックを DiagramState に追加し、undo/redo API を提供
- NetManager に Undo/Redo ボタンを追加してエッジ選択に依存せず操作可能に
- Net ヘルパーのユニットテストを追加し、追加/削除/属性変更/undo/redo をカバー

## Testing
- npm run format
- npm run lint
- npm test
- npm run build
