### PR TITLE
Split DiagramState initial data and net history

### DIFF
--- a/src/state/initialDiagram.ts
+++ b/src/state/initialDiagram.ts
@@ -1,0 +1,43 @@
+import type { Edge, Node } from "reactflow";
+
+const initialNodes: Node[] = [
+  {
+    id: "source",
+    position: { x: 150, y: 120 },
+    data: {
+      label: "Power Source (Type C)",
+      type: "C",
+      rating: {
+        in: { V_in: 200, phase_in: 1 },
+        out: { V_out: 24, phase_out: 0 },
+      },
+    },
+  },
+  {
+    id: "breaker",
+    position: { x: 450, y: 120 },
+    data: { label: "Breaker (Type A)", type: "A", rating: { V_max: 250, I_max: 20, phase: 1 } },
+  },
+  {
+    id: "load",
+    position: { x: 750, y: 120 },
+    data: { label: "Load (Type B)", type: "B", rating: { V_in: 200, phase: 1, I_in: 5 } },
+  },
+];
+
+const initialEdges: Edge[] = [
+  { id: "e1-2", source: "source", target: "breaker", type: "smooth" },
+  { id: "e2-3", source: "breaker", target: "load", type: "smooth" },
+];
+
+const nextCounterFromNodes = (nodes: Node[]): number => {
+  const maxNumericId = nodes.reduce<number>((max, node) => {
+    const match = node.id.match(/(\\d+)$/);
+    const num = match ? Number(match[1]) : Number.NaN;
+    if (!Number.isNaN(num) && num > max) return num;
+    return max;
+  }, 0);
+  return Math.max(maxNumericId, nodes.length);
+};
+
+export { initialNodes, initialEdges, nextCounterFromNodes };

--- a/src/state/netHistory.ts
+++ b/src/state/netHistory.ts
@@ -1,0 +1,46 @@
+import type { Edge } from "reactflow";
+import type { Net } from "../types/diagram";
+
+type Snapshot = { nets: Net[]; edges: Edge[] };
+
+type NetHistory = {
+  past: Snapshot[];
+  future: Snapshot[];
+};
+
+const cloneSnapshot = (nets: Net[], edges: Edge[]): Snapshot => ({
+  nets: nets.map((n) => ({ ...n })),
+  edges: edges.map((e) => ({
+    ...e,
+    data: e.data ? { ...(e.data as Record<string, unknown>) } : undefined,
+  })),
+});
+
+const record = (history: NetHistory, nets: Net[], edges: Edge[]): void => {
+  history.past.push(cloneSnapshot(nets, edges));
+  history.future = [];
+};
+
+const undo = (history: NetHistory, nets: Net[], edges: Edge[]): Snapshot | null => {
+  const last = history.past.pop();
+  if (!last) return null;
+  history.future.push(cloneSnapshot(nets, edges));
+  return last;
+};
+
+const redo = (history: NetHistory, nets: Net[], edges: Edge[]): Snapshot | null => {
+  const next = history.future.pop();
+  if (!next) return null;
+  history.past.push(cloneSnapshot(nets, edges));
+  return next;
+};
+
+const historyState = (history: NetHistory) => ({
+  canUndo: history.past.length > 0,
+  canRedo: history.future.length > 0,
+});
+
+const createHistory = (): NetHistory => ({ past: [], future: [] });
+
+export { createHistory, record, undo, redo, historyState };
+export type { NetHistory, Snapshot };


### PR DESCRIPTION
## Summary
- DiagramState から初期ノード/エッジ定義を  に分離
- Net 用の履歴管理を  に切り出し、DiagramState 本体は API 呼び出しのみで簡潔化
- 既存機能と API は維持しつつ、責務分離で可読性を向上

## Testing
- npm run format
- npm run lint
- npm test
- npm run build
